### PR TITLE
Add support for mind maps

### DIFF
--- a/plugin/generateCards.js
+++ b/plugin/generateCards.js
@@ -3,19 +3,26 @@ import { logEvent } from "./firebase/utils";
 const { board } = window.miro;
 
 const generateCardObjectFor = (object, x, y) => {
-  const objectFillColor = object.style.fillColor;
 
   let cardColor = "#2399f3";
-  if (objectFillColor !== "transparent") {
-    if (COLOR_MAP[objectFillColor]) {
-      cardColor = COLOR_MAP[objectFillColor];
-    } else {
-      cardColor = objectFillColor;
+  
+  if(object?.style?.fillColor) {
+    const objectFillColor = object.style.fillColor;
+
+    if (objectFillColor !== "transparent") {
+      if (COLOR_MAP[objectFillColor]) {
+        cardColor = COLOR_MAP[objectFillColor];
+      } else {
+        cardColor = objectFillColor;
+      }
     }
   }
 
+  // Add support for mind maps with text
+  let title = object?.content || object?.nodeView?.content;
+
   const cardObject = {
-    title: object.content,
+    title: title,
     x: x,
     y: y,
     style: {
@@ -33,7 +40,7 @@ export const generateCards = async () => {
 
   // filtering out shapes from all the selected widgets.
   selectedWidgets = selectedWidgets.filter((item) => {
-    return ["shape", "text", "sticky_note"].includes(item.type);
+    return ["shape", "text", "sticky_note", "mindmap_node"].includes(item.type);
   });
 
   const cardsObjects = selectedWidgets.map((item) =>

--- a/plugin/generateCards.js
+++ b/plugin/generateCards.js
@@ -36,7 +36,7 @@ const generateCardObjectFor = (object, x, y) => {
 
 export const generateCards = async () => {
   // get selected widgets
-  let selectedWidgets = await board.getSelection();
+  let selectedWidgets = await board.experimental.getSelection();
 
   // filtering out shapes from all the selected widgets.
   selectedWidgets = selectedWidgets.filter((item) => {


### PR DESCRIPTION
Hi Yash! I was chatting w/Robert Johnson about the new experimental Mind Map Web SDK in Miro. I figured I could quickly add mind map support into Cardsy rather than building a new app. This PR adds mind map nodes to the list of item types considered for conversion, and then modifies `generateCardObjectFor` to handle the mindmap item schema, detailed here: https://developers.miro.com/docs/mindmap_mindmapnode .

I'm just waiting on Miro to fix a bug where getSelection() doesn't return mind map child nodes, and once they fix that, this should be good. Here's a video of what I mean:

https://www.loom.com/share/a973e2a62de744de9aeb285bfbd3efc5




